### PR TITLE
Changes from background agent bc-fde0cb4c-6b29-4470-b7d6-acec76ce7b54

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "main.c" "logger.c" "canbus.c" "wifi_config.c" "thermocouple.c" "gps.c" "oled.c"
     INCLUDE_DIRS "."
-    REQUIRES driver esp_wifi esp_http_server fatfs sdmmc nvs_flash spiffs
+    REQUIRES driver esp_wifi esp_http_server fatfs sdmmc nvs_flash spiffs esp_timer
 )

--- a/main/gps.h
+++ b/main/gps.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <stdint.h>
+#include "driver/gpio.h"
+#include "driver/uart.h"
 
 // Neo-M8N UART configuration
 #define GPS_UART_NUM     UART_NUM_2

--- a/main/main.c
+++ b/main/main.c
@@ -6,6 +6,7 @@
 #include "driver/gpio.h"
 #include "driver/sdmmc_host.h"
 #include "driver/sdspi_host.h"
+#include "driver/spi_common.h"
 #include "sdmmc_cmd.h"
 #include "esp_vfs_fat.h"
 
@@ -31,13 +32,25 @@ static void init_sdcard(void)
 {
     ESP_LOGI(TAG, "Initializing SD card...");
     
+    // Configure SPI bus
+    spi_bus_config_t bus_cfg = {
+        .mosi_io_num = PIN_NUM_MOSI,
+        .miso_io_num = PIN_NUM_MISO,
+        .sclk_io_num = PIN_NUM_CLK,
+        .quadwp_io_num = -1,
+        .quadhd_io_num = -1,
+        .max_transfer_sz = 4000,
+    };
+    esp_err_t ret = spi_bus_initialize(SPI2_HOST, &bus_cfg, SDSPI_DEFAULT_DMA);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to initialize SPI bus: %s", esp_err_to_name(ret));
+        return;
+    }
+
     sdmmc_host_t host = SDSPI_HOST_DEFAULT();
-    sdspi_slot_config_t slot_config = SDSPI_SLOT_CONFIG_DEFAULT();
-    slot_config.gpio_miso = PIN_NUM_MISO;
-    slot_config.gpio_mosi = PIN_NUM_MOSI;
-    slot_config.gpio_sck  = PIN_NUM_CLK;
-    slot_config.gpio_cs   = PIN_NUM_CS;
-    slot_config.dma_channel = 2;
+    sdspi_device_config_t slot_config = SDSPI_DEVICE_CONFIG_DEFAULT();
+    slot_config.gpio_cs = PIN_NUM_CS;
+    slot_config.host_id = SPI2_HOST;
 
     esp_vfs_fat_sdmmc_mount_config_t mount_config = {
         .format_if_mount_failed = false,
@@ -46,7 +59,7 @@ static void init_sdcard(void)
     };
 
     sdmmc_card_t* card;
-    esp_err_t ret = esp_vfs_fat_sdspi_mount("/sdcard", &host, &slot_config, &mount_config, &card);
+    ret = esp_vfs_fat_sdspi_mount("/sdcard", &host, &slot_config, &mount_config, &card);
 
     if (ret != ESP_OK) {
         if (ret == ESP_FAIL) {

--- a/main/wifi_config.c
+++ b/main/wifi_config.c
@@ -7,6 +7,7 @@
 #include "esp_netif.h"
 #include "esp_http_server.h"
 #include "esp_spiffs.h"
+#include "lwip/ip4_addr.h"
 #include <string.h>
 #include <stdio.h>
 #include <dirent.h>

--- a/main/wifi_config.h
+++ b/main/wifi_config.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <stdint.h>
 
 // Configuration getters
 int get_log_rate(void);


### PR DESCRIPTION
Fixes multiple compilation errors by updating ESP-IDF component requirements, adding missing headers, and modernizing SD card SPI initialization.

The project failed to compile due to:
- Missing `esp_timer` component in `CMakeLists.txt`.
- Missing `driver/gpio.h` and `driver/uart.h` for GPIO definitions.
- Missing `stdint.h` for `uint8_t` type.
- Missing `lwip/ip4_addr.h` for `IP4_ADDR`.
- Outdated SD card SPI configuration API calls (e.g., `sdspi_slot_config_t` and `SDSPI_SLOT_CONFIG_DEFAULT` were replaced with `sdspi_device_config_t` and `SDSPI_DEVICE_CONFIG_DEFAULT`, and SPI bus initialization was added).

---
<a href="https://cursor.com/background-agent?bcId=bc-fde0cb4c-6b29-4470-b7d6-acec76ce7b54">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fde0cb4c-6b29-4470-b7d6-acec76ce7b54">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

