### PR TITLE
Enable oled module for testing

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -10,12 +10,33 @@
 #include "sdmmc_cmd.h"
 #include "esp_vfs_fat.h"
 
+// Module configuration
+#include "module_config.h"
+
+// Conditional module includes
+#ifdef ENABLE_LOGGER_MODULE
 #include "logger.h"
+#endif
+
+#ifdef ENABLE_THERMOCOUPLE_MODULE
 #include "thermocouple.h"
+#endif
+
+#ifdef ENABLE_GPS_MODULE
 #include "gps.h"
+#endif
+
+#ifdef ENABLE_OLED_MODULE
 #include "oled.h"
+#endif
+
+#ifdef ENABLE_CANBUS_MODULE
 #include "canbus.h"
+#endif
+
+#ifdef ENABLE_WIFI_CONFIG_MODULE
 #include "wifi_config.h"
+#endif
 
 static const char *TAG = "MAIN";
 
@@ -28,6 +49,7 @@ static const char *TAG = "MAIN";
 // Power management GPIO
 #define POWER_MONITOR_GPIO GPIO_NUM_34
 
+#ifdef ENABLE_SDCARD_MODULE
 static void init_sdcard(void)
 {
     ESP_LOGI(TAG, "Initializing SD card...");
@@ -74,7 +96,9 @@ static void init_sdcard(void)
     sdmmc_card_print_info(stdout, card);
     ESP_LOGI(TAG, "SD card mounted successfully");
 }
+#endif
 
+#ifdef ENABLE_POWER_MONITORING_MODULE
 static void init_power_monitoring(void)
 {
     // Configure ADC for battery voltage monitoring
@@ -88,6 +112,7 @@ static void init_power_monitoring(void)
     gpio_config(&io_conf);
     ESP_LOGI(TAG, "Power monitoring GPIO configured");
 }
+#endif
 
 void app_main(void)
 {
@@ -105,29 +130,81 @@ void app_main(void)
     ESP_ERROR_CHECK(esp_netif_init());
     ESP_ERROR_CHECK(esp_event_loop_create_default());
 
+#ifdef ENABLE_POWER_MONITORING_MODULE
     // Initialize power monitoring
     init_power_monitoring();
+#endif
 
+#ifdef ENABLE_SDCARD_MODULE
     // Initialize SD card
     init_sdcard();
+#endif
 
+#ifdef ENABLE_WIFI_CONFIG_MODULE
     // Initialize SPIFFS for web interface
     wifi_config_spiffs_init();
+#endif
 
-    // Initialize hardware components
+    // Initialize hardware components based on configuration
+#ifdef ENABLE_THERMOCOUPLE_MODULE
     thermocouple_init();
+#endif
+
+#ifdef ENABLE_GPS_MODULE
     gps_init();
+#endif
+
+#ifdef ENABLE_OLED_MODULE
     oled_init();
-    
+#endif
+
+#ifdef ENABLE_CANBUS_MODULE
+    canbus_init(500); // Default 500 kbps
+#endif
+
+#ifdef ENABLE_WIFI_CONFIG_MODULE
     // Start WiFi AP and web server
     wifi_start_ap();
     webserver_start();
+#endif
 
+#ifdef ENABLE_LOGGER_MODULE
     // Start data logging task
     logger_start();
+#endif
 
     ESP_LOGI(TAG, "ESP32 Data Logger Started Successfully");
+    
+#ifdef ENABLE_WIFI_CONFIG_MODULE
     ESP_LOGI(TAG, "Connect to WiFi: ESP32-LOGGER");
     ESP_LOGI(TAG, "Web interface: http://10.10.10.10");
+#endif
+
+    // Display enabled modules
+    ESP_LOGI(TAG, "Enabled modules:");
+#ifdef ENABLE_OLED_MODULE
+    ESP_LOGI(TAG, "  - OLED Display");
+#endif
+#ifdef ENABLE_THERMOCOUPLE_MODULE
+    ESP_LOGI(TAG, "  - Thermocouple");
+#endif
+#ifdef ENABLE_GPS_MODULE
+    ESP_LOGI(TAG, "  - GPS");
+#endif
+#ifdef ENABLE_CANBUS_MODULE
+    ESP_LOGI(TAG, "  - CAN Bus");
+#endif
+#ifdef ENABLE_WIFI_CONFIG_MODULE
+    ESP_LOGI(TAG, "  - WiFi Configuration");
+#endif
+#ifdef ENABLE_LOGGER_MODULE
+    ESP_LOGI(TAG, "  - Data Logger");
+#endif
+#ifdef ENABLE_SDCARD_MODULE
+    ESP_LOGI(TAG, "  - SD Card");
+#endif
+#ifdef ENABLE_POWER_MONITORING_MODULE
+    ESP_LOGI(TAG, "  - Power Monitoring");
+#endif
 }
 

--- a/main/main.c
+++ b/main/main.c
@@ -9,6 +9,8 @@
 #include "driver/spi_common.h"
 #include "sdmmc_cmd.h"
 #include "esp_vfs_fat.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 // Module configuration
 #include "module_config.h"
@@ -114,6 +116,41 @@ static void init_power_monitoring(void)
 }
 #endif
 
+#ifdef ENABLE_OLED_MODULE
+static void oled_test_task(void *pvParameters) {
+    ESP_LOGI(TAG, "Starting OLED test task...");
+    vTaskDelay(pdMS_TO_TICKS(1000)); // Wait 1 second for initialization
+    
+    ESP_LOGI(TAG, "Running OLED test display...");
+    
+    // Test 1: Clear display
+    oled_clear();
+    vTaskDelay(pdMS_TO_TICKS(500));
+    
+    // Test 2: Display text
+    oled_display_text(0, 0, "ESP32 Working!");
+    oled_display_text(0, 16, "OLED Test OK");
+    oled_display_text(0, 32, "I2C Comm OK");
+    oled_update_display();
+    vTaskDelay(pdMS_TO_TICKS(2000));
+    
+    // Test 3: Counter display
+    int counter = 0;
+    while (1) {
+        oled_clear();
+        oled_display_text(0, 0, "Counter:");
+        char counter_str[16];
+        snprintf(counter_str, sizeof(counter_str), "%d", counter);
+        oled_display_text(0, 16, counter_str);
+        oled_update_display();
+        
+        ESP_LOGI(TAG, "OLED: Counter: %d", counter);
+        counter++;
+        vTaskDelay(pdMS_TO_TICKS(2000));
+    }
+}
+#endif
+
 void app_main(void)
 {
     ESP_LOGI(TAG, "ESP32 Data Logger Starting...");
@@ -156,6 +193,9 @@ void app_main(void)
 
 #ifdef ENABLE_OLED_MODULE
     oled_init();
+    
+    // Start OLED test task
+    xTaskCreate(oled_test_task, "oled_test_task", 4096, NULL, 5, NULL);
 #endif
 
 #ifdef ENABLE_CANBUS_MODULE

--- a/main/module_config.h
+++ b/main/module_config.h
@@ -1,0 +1,28 @@
+#pragma once
+
+// Module Configuration - Enable only ONE module at a time for testing
+// Comment out all modules except the one you want to test
+
+// OLED Display Module
+#define ENABLE_OLED_MODULE
+
+// Thermocouple Module (MAX31855)
+// #define ENABLE_THERMOCOUPLE_MODULE
+
+// GPS Module (Neo-M8N)
+// #define ENABLE_GPS_MODULE
+
+// CAN Bus Module
+// #define ENABLE_CANBUS_MODULE
+
+// WiFi Configuration Module
+// #define ENABLE_WIFI_CONFIG_MODULE
+
+// Data Logger Module
+// #define ENABLE_LOGGER_MODULE
+
+// SD Card Module
+// #define ENABLE_SDCARD_MODULE
+
+// Power Monitoring Module
+// #define ENABLE_POWER_MONITORING_MODULE

--- a/main/oled.c
+++ b/main/oled.c
@@ -60,6 +60,8 @@ static esp_err_t oled_write_data(uint8_t *data, size_t len) {
 
 void oled_init(void) {
     ESP_LOGI(TAG, "Initializing SSD1306 OLED...");
+    ESP_LOGI(TAG, "I2C Config: SDA=GPIO%d, SCL=GPIO%d, Addr=0x%02X", 
+             OLED_SDA_PIN, OLED_SCL_PIN, OLED_ADDR);
     
     i2c_config_t conf = {
         .mode = I2C_MODE_MASTER,
@@ -72,18 +74,27 @@ void oled_init(void) {
     
     esp_err_t ret = i2c_param_config(OLED_I2C_PORT, &conf);
     if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "I2C param config failed");
+        ESP_LOGE(TAG, "I2C param config failed: %s", esp_err_to_name(ret));
         return;
     }
+    ESP_LOGI(TAG, "I2C param config OK");
     
     ret = i2c_driver_install(OLED_I2C_PORT, conf.mode, 0, 0, 0);
     if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "I2C driver install failed");
+        ESP_LOGE(TAG, "I2C driver install failed: %s", esp_err_to_name(ret));
+        return;
+    }
+    ESP_LOGI(TAG, "I2C driver installed");
+    
+    // Test I2C communication
+    ret = oled_write_cmd(SSD1306_DISPLAYOFF);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "I2C communication test failed: %s", esp_err_to_name(ret));
+        ESP_LOGE(TAG, "Check wiring: SDA->GPIO%d, SCL->GPIO%d", OLED_SDA_PIN, OLED_SCL_PIN);
         return;
     }
     
     // Initialize SSD1306
-    oled_write_cmd(SSD1306_DISPLAYOFF);
     oled_write_cmd(SSD1306_SETDISPLAYCLOCKDIV);
     oled_write_cmd(0x80);
     oled_write_cmd(SSD1306_SETMULTIPLEX);
@@ -110,6 +121,13 @@ void oled_init(void) {
     oled_write_cmd(SSD1306_DISPLAYON);
     
     oled_clear();
+    
+    // Display initial test message
+    oled_display_text(0, 0, "ESP32 Data Logger");
+    oled_display_text(0, 16, "OLED Module Test");
+    oled_display_text(0, 32, "Initializing...");
+    oled_update_display();
+    
     ESP_LOGI(TAG, "SSD1306 OLED initialized successfully");
 }
 
@@ -124,11 +142,16 @@ void oled_display_text(int x, int y, const char* text) {
     for (int i = 0; i < len && (x + i * 8) < OLED_WIDTH; i++) {
         char c = text[i];
         if (c >= 32 && c <= 126) {
-            // Simple 8x8 font rendering (simplified)
+            // Simple 8x8 font rendering - create a simple pattern for each character
             for (int row = 0; row < 8 && (y + row) < OLED_HEIGHT; row++) {
-                int buffer_index = (y + row) * (OLED_WIDTH / 8) + (x + i * 8) / 8;
-                if (buffer_index < sizeof(oled_buffer)) {
-                    oled_buffer[buffer_index] |= (1 << ((x + i * 8) % 8));
+                for (int col = 0; col < 8 && (x + i * 8 + col) < OLED_WIDTH; col++) {
+                    int buffer_index = (y + row) * (OLED_WIDTH / 8) + (x + i * 8 + col) / 8;
+                    if (buffer_index < sizeof(oled_buffer)) {
+                        // Create a simple character pattern
+                        if (row == 0 || row == 7 || col == 0 || col == 7) {
+                            oled_buffer[buffer_index] |= (1 << ((x + i * 8 + col) % 8));
+                        }
+                    }
                 }
             }
         }

--- a/switch_module.py
+++ b/switch_module.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+Module switching utility for ESP32 Data Logger
+This script helps you easily switch between different modules for testing
+"""
+
+import os
+import sys
+
+# Available modules
+MODULES = {
+    'oled': 'ENABLE_OLED_MODULE',
+    'thermocouple': 'ENABLE_THERMOCOUPLE_MODULE', 
+    'gps': 'ENABLE_GPS_MODULE',
+    'canbus': 'ENABLE_CANBUS_MODULE',
+    'wifi': 'ENABLE_WIFI_CONFIG_MODULE',
+    'logger': 'ENABLE_LOGGER_MODULE',
+    'sdcard': 'ENABLE_SDCARD_MODULE',
+    'power': 'ENABLE_POWER_MONITORING_MODULE'
+}
+
+def get_current_module():
+    """Get the currently enabled module"""
+    config_file = "/workspace/main/module_config.h"
+    
+    if not os.path.exists(config_file):
+        return None
+    
+    with open(config_file, 'r') as f:
+        content = f.read()
+    
+    for module_name, define in MODULES.items():
+        # Check for uncommented define
+        if f"#define {define}" in content and f"// #define {define}" not in content:
+            return module_name
+    
+    return None
+
+def switch_to_module(target_module):
+    """Switch to the specified module"""
+    if target_module not in MODULES:
+        print(f"❌ Unknown module: {target_module}")
+        print(f"Available modules: {', '.join(MODULES.keys())}")
+        return False
+    
+    config_file = "/workspace/main/module_config.h"
+    
+    if not os.path.exists(config_file):
+        print(f"❌ Configuration file not found: {config_file}")
+        return False
+    
+    with open(config_file, 'r') as f:
+        content = f.read()
+    
+    # Comment out all modules (handle both commented and uncommented states)
+    for module_name, define in MODULES.items():
+        # Remove any existing comments and add new ones
+        content = content.replace(f"#define {define}", f"// #define {define}")
+        content = content.replace(f"// // #define {define}", f"// #define {define}")
+    
+    # Enable the target module
+    target_define = MODULES[target_module]
+    content = content.replace(f"// #define {target_define}", f"#define {target_define}")
+    
+    # Write back to file
+    with open(config_file, 'w') as f:
+        f.write(content)
+    
+    print(f"✅ Switched to {target_module} module")
+    return True
+
+def list_modules():
+    """List all available modules"""
+    print("Available modules:")
+    for module_name, define in MODULES.items():
+        print(f"  - {module_name}: {define}")
+
+def main():
+    if len(sys.argv) < 2:
+        current = get_current_module()
+        if current:
+            print(f"Current module: {current}")
+        else:
+            print("No module currently enabled")
+        print()
+        list_modules()
+        print()
+        print("Usage: python3 switch_module.py <module_name>")
+        print("Example: python3 switch_module.py oled")
+        return
+    
+    target_module = sys.argv[1].lower()
+    
+    if target_module == 'list':
+        list_modules()
+        return
+    
+    current = get_current_module()
+    if current == target_module:
+        print(f"✅ {target_module} module is already enabled")
+        return
+    
+    if switch_to_module(target_module):
+        print(f"🔄 Switched from {current or 'none'} to {target_module}")
+        print("📝 Don't forget to rebuild the project!")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implement a `#define` based module selection system to enable one module at a time for testing, starting with the OLED module.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae23cad6-d4be-4ca6-9808-13d089ce03b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ae23cad6-d4be-4ca6-9808-13d089ce03b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

