### PR TITLE
Test font rendering for lines and circles

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,30 @@ A comprehensive data logging system for ESP32 with 4-channel K-type thermocouple
 - CAN bus activity
 - System status messages
 
+### OLED Tests
+
+Two visual diagnostics are added to validate line/circle rendering and quickly spot font issues.
+
+How to run on device:
+
+1. Build and flash as usual. The firmware starts a `test_task` that runs automatically.
+2. On boot, the display will show, in order:
+   - "OLED TEST" text lines
+   - Line test: border, crosshair, diagonals, and fan lines with header "LINE TEST"
+   - Circle test: concentric and corner circles with header "CIRCLE TEST"
+   - Followed by the existing scrolling log demo
+
+Files of interest:
+
+- `main/oled.h` adds `oled_draw_line`, `oled_draw_circle`, `oled_test_lines`, `oled_test_circles`.
+- `main/oled.c` implements drawing primitives and tests.
+- `main/logger.c` runs the tests in `test_task`.
+
+Notes on fonts:
+
+- The built‑in `font8x8` supports ASCII 32 through `Z`. Lowercase letters are mapped to uppercase.
+- If glyphs look clipped or misaligned during tests, it likely indicates a font bit ordering or buffer addressing issue; the geometric tests help isolate that from font data problems.
+
 ## File Structure
 
 ```

--- a/main/logger.c
+++ b/main/logger.c
@@ -60,6 +60,14 @@ void test_task(void *pv){
     // Run the OLED test display
     oled_test_display();
     vTaskDelay(pdMS_TO_TICKS(2000));
+
+    // Line drawing test
+    oled_test_lines();
+    vTaskDelay(pdMS_TO_TICKS(2000));
+
+    // Circle drawing test
+    oled_test_circles();
+    vTaskDelay(pdMS_TO_TICKS(2000));
     
     // Show some scrolling messages
     ssd1306_scrolllog_init("test_log.txt");

--- a/main/oled.c
+++ b/main/oled.c
@@ -288,6 +288,65 @@ void oled_update_display(void) {
     oled_write_data(oled_buffer, sizeof(oled_buffer));
 }
 
+static void oled_draw_pixel(int x, int y)
+{
+    if (x < 0 || x >= OLED_WIDTH || y < 0 || y >= OLED_HEIGHT) {
+        return;
+    }
+    int buffer_index = (y / 8) * OLED_WIDTH + x;
+    int bit_pos = y % 8;
+    oled_buffer[buffer_index] |= (1 << bit_pos);
+}
+
+void oled_draw_line(int x0, int y0, int x1, int y1)
+{
+    int dx = (x1 > x0) ? (x1 - x0) : (x0 - x1);
+    int sx = (x0 < x1) ? 1 : -1;
+    int dy = (y1 > y0) ? (y1 - y0) : (y0 - y1);
+    int sy = (y0 < y1) ? 1 : -1;
+    int err = dx - dy;
+
+    while (1) {
+        oled_draw_pixel(x0, y0);
+        if (x0 == x1 && y0 == y1) break;
+        int e2 = err << 1;
+        if (e2 > -dy) { err -= dy; x0 += sx; }
+        if (e2 < dx) { err += dx; y0 += sy; }
+    }
+}
+
+static void circle_octants(int xc, int yc, int x, int y)
+{
+    oled_draw_pixel(xc + x, yc + y);
+    oled_draw_pixel(xc - x, yc + y);
+    oled_draw_pixel(xc + x, yc - y);
+    oled_draw_pixel(xc - x, yc - y);
+    oled_draw_pixel(xc + y, yc + x);
+    oled_draw_pixel(xc - y, yc + x);
+    oled_draw_pixel(xc + y, yc - x);
+    oled_draw_pixel(xc - y, yc - x);
+}
+
+void oled_draw_circle(int xc, int yc, int radius)
+{
+    if (radius <= 0) return;
+    int x = 0;
+    int y = radius;
+    int d = 1 - radius;
+    circle_octants(xc, yc, x, y);
+
+    while (y > x) {
+        if (d < 0) {
+            d += (x << 1) + 3;
+        } else {
+            d += ((x - y) << 1) + 5;
+            y--;
+        }
+        x++;
+        circle_octants(xc, yc, x, y);
+    }
+}
+
 void ssd1306_scrolllog_init(const char *logfile) {
     ESP_LOGI(TAG, "OLED log initialized: %s", logfile);
     oled_clear();
@@ -335,4 +394,53 @@ void oled_test_display(void) {
     oled_update_display();
     
     ESP_LOGI(TAG, "OLED test display completed");
+}
+
+void oled_test_lines(void)
+{
+    ESP_LOGI(TAG, "Running OLED line test...");
+    oled_clear();
+
+    // Border
+    oled_draw_line(0, 0, OLED_WIDTH - 1, 0);
+    oled_draw_line(0, OLED_HEIGHT - 1, OLED_WIDTH - 1, OLED_HEIGHT - 1);
+    oled_draw_line(0, 0, 0, OLED_HEIGHT - 1);
+    oled_draw_line(OLED_WIDTH - 1, 0, OLED_WIDTH - 1, OLED_HEIGHT - 1);
+
+    // Crosshair and diagonals
+    oled_draw_line(0, OLED_HEIGHT / 2, OLED_WIDTH - 1, OLED_HEIGHT / 2);
+    oled_draw_line(OLED_WIDTH / 2, 0, OLED_WIDTH / 2, OLED_HEIGHT - 1);
+    oled_draw_line(0, 0, OLED_WIDTH - 1, OLED_HEIGHT - 1);
+    oled_draw_line(0, OLED_HEIGHT - 1, OLED_WIDTH - 1, 0);
+
+    // Fan lines from corners
+    for (int x = 0; x < OLED_WIDTH; x += 8) {
+        oled_draw_line(0, 0, x, OLED_HEIGHT - 1);
+        oled_draw_line(OLED_WIDTH - 1, 0, OLED_WIDTH - 1 - x, OLED_HEIGHT - 1);
+    }
+
+    oled_display_text(2, 2, "LINE TEST");
+    oled_update_display();
+}
+
+void oled_test_circles(void)
+{
+    ESP_LOGI(TAG, "Running OLED circle test...");
+    oled_clear();
+
+    int cx = OLED_WIDTH / 2;
+    int cy = OLED_HEIGHT / 2;
+    int max_r = (OLED_HEIGHT < OLED_WIDTH ? OLED_HEIGHT : OLED_WIDTH) / 2 - 2;
+    for (int r = 4; r <= max_r; r += 6) {
+        oled_draw_circle(cx, cy, r);
+    }
+
+    // Corner circles
+    oled_draw_circle(0 + 10, 0 + 10, 8);
+    oled_draw_circle(OLED_WIDTH - 11, 0 + 10, 8);
+    oled_draw_circle(0 + 10, OLED_HEIGHT - 11, 8);
+    oled_draw_circle(OLED_WIDTH - 11, OLED_HEIGHT - 11, 8);
+
+    oled_display_text(2, 2, "CIRCLE TEST");
+    oled_update_display();
 }

--- a/main/oled.h
+++ b/main/oled.h
@@ -20,3 +20,7 @@ void oled_update_display(void);
 void ssd1306_scrolllog_init(const char *logfile);
 void ssd1306_scrolllog_printf(const char *fmt, ...);
 void oled_test_display(void);
+void oled_draw_line(int x0, int y0, int x1, int y1);
+void oled_draw_circle(int xc, int yc, int radius);
+void oled_test_lines(void);
+void oled_test_circles(void);


### PR DESCRIPTION
Add line and circle drawing primitives and test functions to OLED to diagnose display rendering and font issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-8072fbaf-efaa-4a0d-b232-d0569b541b3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8072fbaf-efaa-4a0d-b232-d0569b541b3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

