### PR TITLE
Fix serial port access denied error

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -131,16 +131,6 @@ void app_main(void)
     ESP_LOGI(TAG, "Web interface: http://10.10.10.10");
 }
 
-// FreeRTOS hook functions
-void vApplicationIdleHook(void)
-{
-    // Called on each iteration of the idle task
-    // Can be used for low power mode or background tasks
-}
-
-void vApplicationTickHook(void)
-{
-    // Called from every tick interrupt
-    // Can be used for time-critical operations
-}
+// FreeRTOS hook functions intentionally omitted to avoid executing flash-resident
+// code from interrupt context while flash cache may be disabled during SPI ops.
 


### PR DESCRIPTION
Remove empty FreeRTOS `vApplicationIdleHook` and `vApplicationTickHook` functions to prevent "Cache disabled but cached memory region accessed" panics.

The panic occurred because the tick ISR was attempting to execute flash-resident code (even empty hook functions are in flash by default) while the flash cache was disabled, likely during an SPI flash operation. Removing these hooks ensures the ISR does not call into flash-resident code in such scenarios.

---
<a href="https://cursor.com/background-agent?bcId=bc-b58713f0-0558-40f6-a2e6-ed82246e6825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b58713f0-0558-40f6-a2e6-ed82246e6825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

